### PR TITLE
address issue with measures and ftypes

### DIFF
--- a/hydrolink/nhd_hr.py
+++ b/hydrolink/nhd_hr.py
@@ -183,19 +183,19 @@ class HighResPoint:
         """
         # hem flowlines within a buffer of coordinates
         if 'hem_flowline' in query:
-            q = f"geometryType=esriGeometryPoint&inSR=4269&geometry={self.init_lon},{self.init_lat}&distance={self.buffer_m}&units=esriSRUnit_Meter&outSR=4269&f=JSON&outFields=GNIS_NAME,LENGTHKM,PERMANENT_IDENTIFIER,REACHCODE&returnM=True"
+            q = f"where=ftype%20NOT%20IN%20(420,428,566)&geometryType=esriGeometryPoint&inSR=4269&geometry={self.init_lon},{self.init_lat}&distance={self.buffer_m}&units=esriSRUnit_Meter&outSR=4269&f=JSON&outFields=gnis_name,lengthkm,permanent_identifier,reachcode&returnM=True"
             base_url = 'https://edits.nationalmap.gov/arcgis/rest/services/HEM/NHDHigh/MapServer/1/query?'
             self.flowline_query = f"{base_url}{q}"
 
         # hem waterbody returns information about hem waterbodies that the point is within
         if 'hem_waterbody' in query:
-            q = f"geometryType=esriGeometryPoint&spatialRel=esriSpatialRelWithin&inSR=4269&geometry={self.init_lon},{self.init_lat}&f=JSON&outFields=PERMANENT_IDENTIFIER,GNIS_NAME,FTYPE,REACHCODE&returnGeometry=False"
+            q = f"geometryType=esriGeometryPoint&spatialRel=esriSpatialRelWithin&inSR=4269&geometry={self.init_lon},{self.init_lat}&f=JSON&outFields=permanent_identifier,gnis_name,ftype,reachcode&returnGeometry=False"
             base_url = 'https://edits.nationalmap.gov/arcgis/rest/services/HEM/NHDHigh/MapServer/2/query?'
             self.waterbody_query = f"{base_url}{q}"
 
         # returns flowlines associated with a waterbody (e.g. reservoir, lake...)
         if 'hem_waterbody_flowline' in query:
-            q = f"where=WBAREA_PERMANENT_IDENTIFIER%20IN%20(%27{self.hydrolink_waterbody['nhdhr waterbody permanent identifier']}%27)&outSR=4269&f=JSON&outFields=GNIS_NAME,LENGTHKM,PERMANENT_IDENTIFIER,REACHCODE&returnM=True"
+            q = f"where=WBAREA_PERMANENT_IDENTIFIER%20IN%20(%27{self.hydrolink_waterbody['nhdhr waterbody permanent identifier']}%27)&outSR=4269&f=JSON&outFields=gnis_name,lengthkm,permanent_identifier,reachcode&returnM=True"
             base_url = 'https://edits.nationalmap.gov/arcgis/rest/services/HEM/NHDHigh/MapServer/1/query?'
             self.flowline_query = f"{base_url}{q}"
 

--- a/hydrolink/nhd_mr.py
+++ b/hydrolink/nhd_mr.py
@@ -180,11 +180,11 @@ class MedResPoint:
 
         """
         if 'network_flow' in query:
-            q = f"geometryType=esriGeometryPoint&inSR=4269&geometry={self.init_lon},{self.init_lat}&distance={self.buffer_m}&units=esriSRUnit_Meter&outSR=4269&f=JSON&outFields=GNIS_NAME,LENGTHKM,REACHCODE,COMID,TERMINALFLAG&returnM=True"
+            q = f"where=FTYPE%20NOT%20IN%20(420,428,566)&geometryType=esriGeometryPoint&inSR=4269&geometry={self.init_lon},{self.init_lat}&distance={self.buffer_m}&units=esriSRUnit_Meter&outSR=4269&f=JSON&outFields=GNIS_NAME,LENGTHKM,REACHCODE,COMID,TERMINALFLAG&returnM=True"
             base_url = 'https://watersgeo.epa.gov/arcgis/rest/services/NHDPlus/NHDPlus/MapServer/2/query?'
             self.flowline_query = f"{base_url}{q}"
         if 'nonnetwork_flow' in query:
-            q = f"geometryType=esriGeometryPoint&inSR=4269&geometry={self.init_lon},{self.init_lat}&distance={self.buffer_m}&units=esriSRUnit_Meter&outSR=4269&f=JSON&outFields=GNIS_NAME,LENGTHKM,REACHCODE,COMID&returnM=True"
+            q = f"where=FTYPE%20NOT%20IN%20(420,428,566)&geometryType=esriGeometryPoint&inSR=4269&geometry={self.init_lon},{self.init_lat}&distance={self.buffer_m}&units=esriSRUnit_Meter&outSR=4269&f=JSON&outFields=GNIS_NAME,LENGTHKM,REACHCODE,COMID&returnM=True"
             base_url = 'https://watersgeo.epa.gov/arcgis/rest/services/NHDPlus/NHDPlus/MapServer/3/query?'
             self.nonnetwork_flowline_query = f"{base_url}{q}"
         if 'waterbody' in query:

--- a/hydrolink/utils.py
+++ b/hydrolink/utils.py
@@ -138,8 +138,10 @@ def nhd_flowline_measure(flowline_geo, node_measures, flowline_snap_point):
 
     if flowline_line.project(min_node_point) > flowline_line.project(max_node_point):
         nhd_measure = (float(max(node_measures)) - ((float(flowline_total_meas) * float(length_line_to_point)) / float(length_line_total)))
-    else:
+    elif length_line_total != 0:
         nhd_measure = (((float(flowline_total_meas) * float(length_line_to_point)) / float(length_line_total)) + float(min(node_measures)))
+    else:
+        nhd_measure = None
 
     return nhd_measure
 


### PR DESCRIPTION
Update queries to not include coastlines, pipelines and underground conduits.

Also fix issue with measures that have a denominator of 0 (i.e. island coastlines with same start/finish node).